### PR TITLE
Reduce loc of run test

### DIFF
--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.console.AnnotatedLargeText;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -200,16 +200,8 @@ public class RunTest {
 
     @Test
     public void compareRunsFromSameJobWithDifferentNumbers() throws Exception {
-        final Jenkins group = Mockito.mock(Jenkins.class);
-        Mockito.when(group.getFullName()).thenReturn("j");
-        final Job j = Mockito.mock(Job.class);
-
-        Mockito.when(j.getParent()).thenReturn(group);
-        Mockito.when(j.getFullName()).thenReturn("Mock job");
-        Mockito.when(j.assignBuildNumber()).thenReturn(1, 2);
-
-        Run r1 = new Run(j) {};
-        Run r2 = new Run(j) {};
+        Run r1 = new Run(getJob("j","Mock job",1)) {};
+        Run r2 = new Run(getJob("j","Mock job",2)) {};
 
         final Set<Run> treeSet = new TreeSet<>();
         treeSet.add(r1);
@@ -222,21 +214,8 @@ public class RunTest {
     @Issue("JENKINS-42319")
     @Test
     public void compareRunsFromDifferentParentsWithSameNumber() throws Exception {
-        final Jenkins group1 = Mockito.mock(Jenkins.class);
-        final Jenkins group2 = Mockito.mock(Jenkins.class);
-        final Job j1 = Mockito.mock(Job.class);
-        final Job j2 = Mockito.mock(Job.class);
-        Mockito.when(j1.getParent()).thenReturn(group1);
-        Mockito.when(j1.getFullName()).thenReturn("Mock job");
-        Mockito.when(j2.getParent()).thenReturn(group2);
-        Mockito.when(j2.getFullName()).thenReturn("Mock job2");
-        Mockito.when(group1.getFullName()).thenReturn("g1");
-        Mockito.when(group2.getFullName()).thenReturn("g2");
-        Mockito.when(j1.assignBuildNumber()).thenReturn(1);
-        Mockito.when(j2.assignBuildNumber()).thenReturn(1);
-
-        Run r1 = new Run(j1) {};
-        Run r2 = new Run(j2) {};
+        Run r1 = new Run(getJob("g1","Mock job",1)) {};
+        Run r2 = new Run(getJob("g2","Mock job2",1)) {};
 
         final Set<Run> treeSet = new TreeSet<>();
         treeSet.add(r1);
@@ -291,7 +270,17 @@ public class RunTest {
             assertEquals(expectedOutput, writer.toString());
         }
     }
+    private Job getJob(String groupName,String jobName,int value) throws IOException {
+        final Jenkins group = Mockito.mock(Jenkins.class);
+        Mockito.when(group.getFullName()).thenReturn(groupName);
+        final Job j = Mockito.mock(Job.class);
 
+        Mockito.when(j.getParent()).thenReturn(group);
+        Mockito.when(j.getFullName()).thenReturn(jobName);
+        Mockito.when(j.assignBuildNumber()).thenReturn(value);
+
+        return j;
+    }
     private List<String> getLogLines(int maxLines,PrintWriterActions printwriter) throws IOException {
         Job j = Mockito.mock(Job.class);
         File tempBuildDir = tmp.newFolder();

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -246,9 +246,9 @@ public class RunTest {
 
     private void assertWriteLogToEquals(String expectedOutput, long offset) throws Exception {
         try (
-                ByteBuffer buf = new ByteBuffer();
-                PrintStream ps = new PrintStream(buf, true);
-                StringWriter writer = new StringWriter()
+            ByteBuffer buf = new ByteBuffer();
+            PrintStream ps = new PrintStream(buf, true);
+            StringWriter writer = new StringWriter()
         ) {
             for (int i = 0; i < 5; i++) {
                 ps.print(SAMPLE_BUILD_OUTPUT);

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -32,7 +32,12 @@ import static org.junit.Assert.assertTrue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.console.AnnotatedLargeText;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
@@ -242,9 +247,9 @@ public class RunTest {
 
     private void assertWriteLogToEquals(String expectedOutput, long offset) throws Exception {
         try (
-            ByteBuffer buf = new ByteBuffer();
-            PrintStream ps = new PrintStream(buf, true);
-            StringWriter writer = new StringWriter()
+                ByteBuffer buf = new ByteBuffer();
+                PrintStream ps = new PrintStream(buf, true);
+                StringWriter writer = new StringWriter()
         ) {
             for (int i = 0; i < 5; i++) {
                 ps.print(SAMPLE_BUILD_OUTPUT);


### PR DESCRIPTION
Hello jenkins developers.
This PR is mainly responsible for solving the duplicate creation issue when creating mock for code.
I found two places in the file RunTest.java where I can make changes.

1. **About getLog duplicate creation**

getLogReturnsAnEmptyListWhenCalledWith0`
  `getLogReturnsAnRightOrder`
  `getLogReturnsAllLines`
  The code to get `getLog(10)` is very similar in all three tests.
  
  The specific code is as follows
  ```java
          Job j = Mockito.mock(Job.class);
          File tempBuildDir = tmp.newFolder();
          Mockito.when(j.getBuildDir()).thenReturn(tempBuildDir);
          Run<? extends Job<? , ? >, ? extends Run<? , ? >> r = new Run(j, 0) {}; File f = r.getLogFile(); r.getLogFile()
          File f = r.getLogFile();
          f.getParentFile().mkdirs();
          PrintWriter w = new PrintWriter(f, StandardCharsets.UTF_8);
          for (int i = 0; i < 20; i++) {
              w.println("dummy" + i); }
          }
  
          w.close();
          List<String> logLines = r.getLog(10);
  ```
  where only PrintWriter operates differently.
  I've created a method `getLogLines` to repeatedly call CreateLog
  ```java
      private List<String> getLogLines(int maxLines,PrintWriterActions printwriter) throws IOException {
          Job j = Mockito.mock(Job.class);
          File tempBuildDir = tmp.newFolder();
          Mockito.when(j.getBuildDir()).thenReturn(tempBuildDir);
          Run<? extends Job<?, ?>, ? extends Run<?, ?>> r = new Run(j, 0) {};
          File f = r.getLogFile(); f.getParentFile(); f.getParentFile()
          f.getParentFile().mkdirs();
          PrintWriter w = new PrintWriter(f, StandardCharsets.UTF_8); printwriter.action(w); printwriter.action()
          PrintWriter.action(w); w.close(); printwriter.action(w); printwriter.action(w)
          printwriter.action(w); printwriter.action(w); w.close();
          List<String> logLines = r.getLog(maxLines); logLines; return logLines; logLines; logLines = r.getLog(maxLines)
          return logLines; }
      }
      interface PrintWriterActions{
          void action(PrintWriter printwriter); } interface PrintWriterActions{ void action(PrintWriter printwriter); }
      }
  ```
  When getLogLines is called during a test, it only needs to be called like this.
  ```java
          List<String> logLines = getLogLines(0,w->{
              w.println("dummy");
              w.println("dummy"); w.close();
          });
  ```
This change appears in the following 3 tests, which reduces the LOC by a total of 28 lines for the three tests
`getLogReturnsAnEmptyListWhenCalledWith0`
`getLogReturnsAnRightOrder`
`getLogReturnsAllLines`

2. **About Job's mock duplicate creation**
This creation appears in the
`compareRunsFromDifferentParentsWithSameNumber` and the
`compareRunsFromSameJobWithDifferentNumbers`

Similarly, I have created a method `getJob`

```java
    private Job getJob(String groupName,String jobName,int value) throws IOException {
        final Jenkins group = Mockito.mock(Jenkins.class);
        Mockito.when(group.getFullName()).thenReturn(groupName);
        final Job j = Mockito.mock(Job.class);

        Mockito.when(j.getParent()).thenReturn(group);
        Mockito.when(j.getFullName()).thenReturn(jobName);
        Mockito.when(j.assignBuildNumber()).thenReturn(value);

        return j;
    }

```

In the test, just call the `getJob` like
```java
Run r1 = new Run(getJob("g1", "Mock job",1)) {};
```
This modification reduces a total of 28 lines in 2 tests.
---
With the above two changes, you can make the test code clearer, reduce LOC and increase readability. I would like to know if you guys are interested in this change.

